### PR TITLE
(POC) page.goto should resolve to response for redirected and intercepted

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -474,9 +474,11 @@ class Page extends EventEmitter {
   async goto(url, options) {
     const referrer = this._networkManager.extraHTTPHeaders()['referer'];
 
-    const requests = new Map();
+    const responses = new Map();
     const eventListeners = [
-      helper.addEventListener(this._networkManager, NetworkManager.Events.Request, request => requests.set(request.url(), request))
+      helper.addEventListener(this._networkManager, NetworkManager.Events.Response, response => {
+        responses.set(response.url(), response);
+      })
     ];
 
     const mainFrame = this._frameManager.mainFrame();
@@ -492,8 +494,7 @@ class Page extends EventEmitter {
     helper.removeEventListeners(eventListeners);
     if (error)
       throw error;
-    const request = requests.get(this.mainFrame().url());
-    return request ? request.response() : null;
+    return responses.get(this.mainFrame().url()) || null;
 
     /**
      * @param {!Puppeteer.Session} client


### PR DESCRIPTION
`page.goto` sometimes resolves to `null`.

There are several cases, but one case is when `setRequestInterception(true)` is set and also redirect is caused.

In my environment (Accept-Language: ja-JP), the following URLs cause redirects and result in `null` response.

- http://giffysk8s.blogspot.com/ -> http://giffysk8s.blogspot.jp/
- http://lemaninignesinden.blogspot.com/2015/02/vitaminenzimklorofilsifa.html -> http://lemaninignesinden.blogspot.jp/2015/02/vitaminenzimklorofilsifa.html
- http://henke-s.blogspot.com/ -> http://henke-s.blogspot.jp/

The problem should be fixed by this PR. The test script can be found [here](https://github.com/GoogleChrome/puppeteer/issues/1391#issue-274055925).

**Note**

This is a POC and not tested enough.